### PR TITLE
Feature/receive parameters dinamically

### DIFF
--- a/.github/workflows/terraform-template-creation-resource.yml
+++ b/.github/workflows/terraform-template-creation-resource.yml
@@ -160,7 +160,7 @@ jobs:
     - name: Terraform Apply
       id: apply
       run: |
-        APPLY_ARGS="auto-approve -input=false"
+        APPLY_ARGS="-auto-approve -input=false"
         
         # Add terraform.tfvars if it exists and has content
         if [ -f terraform.tfvars ] && [ -s terraform.tfvars ]; then

--- a/.github/workflows/terraform-template-destroy-resource.yml
+++ b/.github/workflows/terraform-template-destroy-resource.yml
@@ -2,17 +2,19 @@ name: 'Reusable Terraform Destroy Workflow'
 
 on:
   workflow_call:
-    secrets:
-      AZURE_CLIENT_ID:
+    inputs:
+      terraform_var_mapping:
+        description: 'JSON mapping of terraform variables to secret names'
         required: true
-      AZURE_CLIENT_SECRET:
-        required: true
-      AZURE_SUBSCRIPTION_ID:
-        required: true
-      AZURE_TENANT_ID:
-        required: true
-      TF_API_TOKEN:
-        required: false
+        type: string
+    secrets: {}  # No explicit secrets defined 
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
 
 jobs:
   terraform-destroy:
@@ -40,6 +42,41 @@ jobs:
     - name: Terraform Init
       run: terraform init -input=false
 
-    # Run the destroy command to remove all resources defined in the Terraform configuration
+    - name: Generate Terraform Variables from Secrets
+      env:
+        SECRETS_CONTEXT: ${{ toJson(secrets) }}
+        VAR_MAPPING: ${{ inputs.terraform_var_mapping }}
+      run: |
+        # Create terraform.tfvars file
+        echo "# Generated Terraform variables from secrets" > terraform.tfvars
+        
+        # Parse the mapping and generate variables
+        echo "$VAR_MAPPING" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read tf_var secret_name; do
+          # Get the secret value from the secrets context
+          secret_value=$(echo "$SECRETS_CONTEXT" | jq -r --arg secret_name "$secret_name" '.[$secret_name] // empty')
+          
+          if [ -n "$secret_value" ] && [ "$secret_value" != "null" ]; then
+            echo "${tf_var} = \"${secret_value}\"" >> terraform.tfvars
+            echo "✓ Mapped secret '$secret_name' to terraform variable '$tf_var'"
+          else
+            echo "⚠️  Warning: Secret '$secret_name' not found or empty for terraform variable '$tf_var'"
+          fi
+        done
+        
+        echo "Generated terraform.tfvars:"
+        # Show tfvars without values for security
+        sed 's/=.*/= "[REDACTED]"/' terraform.tfvars
+
     - name: Terraform Destroy
-      run: terraform destroy -auto-approve -input=false
+      id: apply
+      run: |
+        APPLY_ARGS="-auto-approve -input=false"
+        
+        # Add terraform.tfvars if it exists and has content
+        if [ -f terraform.tfvars ] && [ -s terraform.tfvars ]; then
+          APPLY_ARGS="$APPLY_ARGS -var-file=terraform.tfvars"
+        fi
+
+        echo "Running: terraform destroy $APPLY_ARGS"
+
+        terraform destroy $APPLY_ARGS

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ on:
 jobs:
   destroy:
     uses: Grupo-118-Tech-Challenge-Fiap-11SOAT/terraform-template-pipeline-grupo118-fase-3/.github/workflows/terraform-template-destroy-resource.yml@main
+    with:
+      terraform_var_mapping: |
+        {
+          "environment": "ENVIRONMENT",
+          "region": "AZURE_REGION",
+          "instance_count": "INSTANCE_COUNT",
+          "database_password": "DB_PASSWORD",
+          "api_key": "API_SECRET_KEY"
+        }
     secrets: inherit
 ```
 


### PR DESCRIPTION
This pull request refactors the reusable Terraform destroy workflow to improve secret management and variable mapping. The main changes include switching from explicit secret declarations to a flexible input-based mapping, dynamically generating the `terraform.tfvars` file from secrets, and updating documentation to show how to use the new mapping approach.

**Terraform workflow improvements:**

* The destroy workflow now accepts a JSON mapping (`terraform_var_mapping`) of Terraform variable names to secret names as an input, instead of requiring secrets to be explicitly declared. This makes the workflow more flexible and reusable across different environments.
* A new job step dynamically generates the `terraform.tfvars` file by reading the provided mapping and extracting secret values, making it easier to pass secrets as variables to Terraform. The workflow logs which secrets were mapped and redacts values in output for security.

**Documentation update:**

* The `README.md` has been updated to show an example of how to use the new `terraform_var_mapping` input when calling the destroy workflow, including a sample mapping of variables to secrets.

**Minor workflow fix:**

* The `Terraform Apply` and `Terraform Destroy` steps now use the correct Terraform CLI flag syntax by adding a leading dash to `-auto-approve`. [[1]](diffhunk://#diff-b976f4caa0ca0305adeb42d6cbbac69b3ee4d7a9e2c0686c586225bf914b2cbeL163-R163) [[2]](diffhunk://#diff-daac5c7f293610fc0ec644d420f919844445decc2705ab2898bceef6f1699220L43-R82)